### PR TITLE
redis: fix panic when evict some key

### DIFF
--- a/proc/redis/hotkey/counter.go
+++ b/proc/redis/hotkey/counter.go
@@ -165,7 +165,7 @@ func (n *freqNode) PopItem() *itemNode {
 
 	item := n.itemHead
 	item.next.prev = nil
-	n.itemHead = item
+	n.itemHead = item.next
 	return item
 }
 

--- a/proc/redis/hotkey/counter_test.go
+++ b/proc/redis/hotkey/counter_test.go
@@ -15,8 +15,11 @@
 package hotkey
 
 import (
+	"fmt"
+	"math/rand"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -58,4 +61,13 @@ func TestCounterFree(t *testing.T) {
 	c := NewCounter(3, freeCb)
 	c.Free()
 	assert.True(t, called)
+}
+
+func TestCounterChaoticIncr(t *testing.T) {
+	c := NewCounter(16, nil)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 10000; i++ {
+		key := fmt.Sprintf("k%d", rand.Intn(100))
+		c.Incr(key)
+	}
 }


### PR DESCRIPTION
Here are the recipe for reproducing the panic:

1.  create a counter and its capacity is 3.
2. execute `c.Incr("k1")`  `c.Incr("k2")` `c.Incr("k3")` ` c.Incr("k4")` in order.
3. execute `c.Incr("k2")` again, and you could see the panic.