### PR TITLE
redis: fix client hangs when the pipeline buffer is full

### DIFF
--- a/proc/redis/upstream.go
+++ b/proc/redis/upstream.go
@@ -637,7 +637,12 @@ func (c *client) loopWrite() {
 				goto FAIL
 			}
 		}
-		c.processingReqs <- req
+
+		select {
+		case <-c.quit:
+			return
+		case c.processingReqs <- req:
+		}
 	}
 
 FAIL:


### PR DESCRIPTION
When the internal pipeline buffer is full, the client can't exit when the underlying network is broken.

fix #32 